### PR TITLE
fix(register-page): submitting flag should be set to false on non-matching password

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -28,6 +28,7 @@ const Register: NextPage = () => {
     const values = getValues();
     if (values.password !== values.repeatPassword) {
       setError('Lozinke se ne podudaraju');
+      setSubmitting(false);
       return;
     }
 


### PR DESCRIPTION
If you type non-matching passwords on your first try you can't resubmit the register form since the `submitting` flag is always left as `true` which disables the button to submit.
```html
<button
  disabled={submitting}
  ...
```