### PR TITLE
[Feature] Enable admins to upload certificates on behalf of user

### DIFF
--- a/src/app/admin/users/profile/[id]/page.tsx
+++ b/src/app/admin/users/profile/[id]/page.tsx
@@ -11,15 +11,10 @@ import * as Switch from '@radix-ui/react-switch';
 import updateUser from '@/services/user/update';
 import { toast } from 'react-toastify';
 import AdminLayout from '@/shared/layouts/adminLayout';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import { useRouter } from 'next/navigation';
+import CertificateTable from '@/app/profile/certificates/components/certificateTable/CertificateTable';
+import { CertificateDto } from '@/app/profile/certificates/models/certificate.model';
+import CertificateForm from '@/app/profile/certificates/components/certificateForm/CertificateForm';
 
 interface Props {
   params: { id: string };
@@ -27,6 +22,7 @@ interface Props {
 
 const UserProfile: React.FC<Props> = ({ params }) => {
   const [user, setUser] = useState<UserDto | null>(null);
+  const [certificates, setCertificates] = useState<CertificateDto[]>([]);
   const [isLoading, setLoading] = useState(true);
   const [active, setActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -38,6 +34,9 @@ const UserProfile: React.FC<Props> = ({ params }) => {
       if (response) {
         setUser(response);
         setActive(response.active);
+        if (response.userAttributes?.certificates) {
+          setCertificates(response.userAttributes?.certificates);
+        }
       }
       setLoading(false);
     };
@@ -60,6 +59,14 @@ const UserProfile: React.FC<Props> = ({ params }) => {
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const onCertificateDelete = ({ id }: CertificateDto) => {
+    setCertificates(certificates.filter((c) => c.id !== id));
+  };
+
+  const onCertificateCreate = (certificate: CertificateDto) => {
+    setCertificates([...certificates, certificate]);
   };
 
   if (isLoading) return <>Loading...</>;
@@ -195,41 +202,18 @@ const UserProfile: React.FC<Props> = ({ params }) => {
           </CardHeader>
 
           <CardContent className="space-y-4">
+            <div className="mb-5">
+              <CertificateForm
+                userId={Number(params.id)}
+                onCertificateCreate={onCertificateCreate}
+              />
+            </div>
             <div className="rounded-lg border shadow-sm">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[80px]">ID</TableHead>
-                    <TableHead className="hidden md:table-cell">Type</TableHead>
-                    <TableHead className="hidden md:table-cell">Key</TableHead>
-                    <TableHead className="hidden md:table-cell">
-                      Valid till
-                    </TableHead>
-                    <TableHead>Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {user.userAttributes?.certificates?.map((certificate) => (
-                    <TableRow key={certificate.id}>
-                      <TableCell>{certificate.id}</TableCell>
-                      <TableCell className="md:table-cell">
-                        {certificate.type}
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        {certificate.key}
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        {getFullYear(certificate.validTill.toString())}
-                      </TableCell>
-                      <TableCell>
-                        <Button className="ml-2" size="sm" variant="outline">
-                          Delete
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <CertificateTable
+                certificates={certificates}
+                onCertificateDelete={onCertificateDelete}
+                allowedActions={['delete', 'download']}
+              />
             </div>
           </CardContent>
         </Card>

--- a/src/app/profile/certificates/components/certificateForm/CertificateForm.tsx
+++ b/src/app/profile/certificates/components/certificateForm/CertificateForm.tsx
@@ -23,13 +23,15 @@ type CertificateFormInputs = {
   type: CertificateTypeEnum | '';
   validTill: Date;
   key: string;
+  userId?: number;
 };
 
 type CertificateFormProps = {
   onCertificateCreate: (certificate: CertificateDto) => void;
+  userId?: number;
 };
 
-const CertificateForm: FC<CertificateFormProps> = ({ onCertificateCreate }) => {
+const CertificateForm: FC<CertificateFormProps> = ({ onCertificateCreate, userId }) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<CertificateFormInputs>({
     defaultValues: {
@@ -51,6 +53,7 @@ const CertificateForm: FC<CertificateFormProps> = ({ onCertificateCreate }) => {
         key: data.key,
         type: data.type,
         validTill: new Date(data.validTill).toISOString(),
+        userId,
       });
 
       onCertificateCreate(certificate);

--- a/src/app/profile/certificates/components/certificateTable/CertificateTable.tsx
+++ b/src/app/profile/certificates/components/certificateTable/CertificateTable.tsx
@@ -40,7 +40,6 @@ export const resolveIcon = (type: CertificateTypeEnum) => {
   return <></>;
 };
 
-// TODO: Look into passing certificates as a prop
 const CertificateTable: FC<CertificateTableProps> = ({
   certificates,
   onCertificateDelete,

--- a/src/app/profile/certificates/models/certificate.model.ts
+++ b/src/app/profile/certificates/models/certificate.model.ts
@@ -10,4 +10,5 @@ export type CreateCertificateDto = {
   type: string;
   validTill: string;
   key: string;
+  userId?: number;
 };

--- a/src/app/profile/certificates/services/certificates-service.ts
+++ b/src/app/profile/certificates/services/certificates-service.ts
@@ -16,11 +16,9 @@ const fetchCertificates = async (userId: number): Promise<CertificateDto[]> => {
 const createCertificate = async (
   certificate: CreateCertificateDto
 ): Promise<CertificateDto> => {
-  if (certificate.userId) {
-    return post(`${APIs.CERTIFICATE}/create-on-behalf-of`, certificate);
-  }
+  const requestUrl = `${APIs.CERTIFICATE}/${certificate.userId ? 'create-on-behalf-of' : ''}`;
 
-  return post(APIs.CERTIFICATE, certificate);
+  return post(requestUrl, certificate);
 };
 
 const downloadCertificate = async (certificateId: number) => {

--- a/src/app/profile/certificates/services/certificates-service.ts
+++ b/src/app/profile/certificates/services/certificates-service.ts
@@ -9,15 +9,17 @@ import {
   CreateCertificateDto,
 } from '../models/certificate.model';
 
-const fetchCertificates = async (
-  userId: number
-): Promise<CertificateDto[]> => {
+const fetchCertificates = async (userId: number): Promise<CertificateDto[]> => {
   return get<CertificateDto[]>(`${APIs.CERTIFICATE}?userId=${userId}`);
 };
 
 const createCertificate = async (
   certificate: CreateCertificateDto
 ): Promise<CertificateDto> => {
+  if (certificate.userId) {
+    return post(`${APIs.CERTIFICATE}/create-on-behalf-of`, certificate);
+  }
+
   return post(APIs.CERTIFICATE, certificate);
 };
 

--- a/src/services/user/dto/user.dto.ts
+++ b/src/services/user/dto/user.dto.ts
@@ -23,7 +23,7 @@ export type UserAttributesDto = {
   certificates?: Certificate[];
 };
 
-type OrganisationAttributesDto = {
+export type OrganisationAttributesDto = {
   id: number;
   name: string;
   street: string;
@@ -31,7 +31,7 @@ type OrganisationAttributesDto = {
   oib: string;
 };
 
-type Certificate = {
+export type Certificate = {
   id: number;
   type: CertificateTypeEnum;
   validTill: Date;


### PR DESCRIPTION
## Description
Enable admins to upload a certificate on behalf of a user by adding the form in the `/admin/users/profile` route.

## Change summary
- Expend the current `CreateCertificate` component to accept a `userId` prop
- Expend the current `createCertificate` method so it handles an optional `userId` param and calls the appropriate API endpoint

## Checklist

- [x] I have performed a self-review of my code
- [x] I tested locally
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New package or package update introduced
